### PR TITLE
argument to t.index can be an array

### DIFF
--- a/lib/rails/strong_parameters.rb
+++ b/lib/rails/strong_parameters.rb
@@ -38,8 +38,14 @@ It uses string_parameters to replace attr_accessible.
       object_name = eval(node.caller.arguments.first.to_source).singularize
       attributes[object_name] = []
       with_node type: 'send', receiver: 't' do
-        attribute_name = eval(node.arguments.first.to_source).to_sym
-        attributes[object_name] << attribute_name
+        column_name_or_names = eval(node.arguments.first.to_source)
+        column_names =  case column_name_or_names
+                        when String
+                          [column_name_or_names.to_sym]
+                        when Array
+                          column_name_or_names.map(&:to_sym)
+                        end
+        attributes[object_name] += column_names
       end
     end
   end


### PR DESCRIPTION
in my code base they are always an array but I presume different versions of rails may handle that differently,
but fix should work in both cases (no unit test added, but works locally)
