### PR TITLE
update rails upgrade_3_2_to_4_0 snippet

### DIFF
--- a/lib/rails/upgrade_3_2_to_4_0.rb
+++ b/lib/rails/upgrade_3_2_to_4_0.rb
@@ -207,6 +207,14 @@ It upgrades rails from 3.2 to 4.0.
   within_files 'app/models/**/*.rb' do
     # scope :active, where(active: true) => scope :active, -> { where(active: true) }
     with_node type: 'send', receiver: nil, message: 'scope' do
+      with_node type: 'send', receiver: nil, message: 'proc' do
+        replace_with '->'
+      end
+
+      with_node type: 'send', receiver: {type: 'const', to_source: 'Proc'}, message: 'new' do
+        replace_with '->'
+      end
+
       unless_exist_node type: 'block', caller: {type: 'send', message: 'lambda'} do
         replace_with 'scope {{arguments.first}}, -> { {{arguments.last}} }'
       end

--- a/spec/rails/upgrade_3_2_to_4_0_spec.rb
+++ b/spec/rails/upgrade_3_2_to_4_0_spec.rb
@@ -147,6 +147,9 @@ end
 class Post < ActiveRecord::Base
   has_many :comments, dependent: :restrict
   scope :active, where(active: true)
+  scope :published, Proc.new { where(published: true) }
+  scope :trashed, proc { where(trashed: false) }
+
   default_scope order("updated_at DESC")
 
   attr_accessible :title, :description
@@ -200,6 +203,9 @@ end
 class Post < ActiveRecord::Base
   has_many :comments, dependent: :restrict_with_exception
   scope :active, -> { where(active: true) }
+  scope :published, -> { where(published: true) }
+  scope :trashed, -> { where(trashed: false) }
+
   default_scope -> { order("updated_at DESC") }
 
   def serialized_attrs


### PR DESCRIPTION
For the users who has been using Proc.new or proc for scope argument in their model, it would be good to skip adding lambda to scope when the ones are passed.
