### PR TITLE
Add new_hash_syntax_ruby22

### DIFF
--- a/lib/ruby/new_hash_syntax_ruby22.rb
+++ b/lib/ruby/new_hash_syntax_ruby22.rb
@@ -1,0 +1,34 @@
+Synvert::Rewriter.new 'ruby', 'new_hash_syntax' do
+  description <<-'EOF'
+Use ruby new hash syntax extended in ruby 2.2.
+
+    {:foo => 'bar'} => {foo: 'bar'}
+    {:'foo-x' => 'bar'} => {'foo-x': 'bar'}
+    {:"foo-#{suffix}" 'bar'} => {"foo-#{suffix}": 'bar'}
+  EOF
+
+  # Gem::Version initialize will strip RUBY_VERSION directly in ruby 1.9,
+  # which is solved from ruby 2.0.0, which calls dup internally.
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.2.0")
+    within_files '**/*.rb' do
+      # {:foo => 'bar'} => {foo: 'bar'}
+      within_node type: 'hash' do
+        with_node type: 'pair' do
+          case node.key.type
+          when :sym
+            case node.key.children.first.inspect
+            when /\A:"([^"'\\]*)"\z/
+              replace_with "'#{$1}': {{value}}"
+            when /\A:(.+)\z/
+              replace_with "#{$1}: {{value}}"
+            end
+          when :dsym
+            if new_key = node.key.to_source[/\A:(.+)/, 1]
+              replace_with "#{new_key}: {{value}}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby/new_hash_syntax_spec_ruby22.rb
+++ b/spec/ruby/new_hash_syntax_spec_ruby22.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe 'Ruby uses new hash synax in ruby 2.2' do
+  before do
+    rewriter_path = File.join(File.dirname(__FILE__), '../../lib/ruby/new_hash_syntax_ruby22.rb')
+    @rewriter = eval(File.read(rewriter_path))
+  end
+
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
+    describe 'with fakefs', fakefs: true do
+      let(:test_content) {
+        <<'EOF'
+{:foo => 'bar', 'foo' => 'bar'}
+{:key1 => 'value1', :key2 => 'value2'}
+{foo_key: 'foo_value', bar_key: 42, "baz-key" => true}
+{:"foo-#{key}" => 'foo_value', :"bar-key" => 42, :"a\tb" => false, :"c'd" => nil}
+{"foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil, %Q"baz-#{key}": true}
+EOF
+      }
+
+      let(:test_rewritten_content) {
+        <<'EOF'
+{foo: 'bar', 'foo' => 'bar'}
+{key1: 'value1', key2: 'value2'}
+{foo_key: 'foo_value', bar_key: 42, "baz-key" => true}
+{"foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil}
+{"foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil, %Q"baz-#{key}": true}
+EOF
+      }
+
+      it 'converts' do
+        File.write 'test.rb', test_content
+        @rewriter.process
+        expect(File.read 'test.rb').to eq test_rewritten_content
+      end
+    end
+  end
+end


### PR DESCRIPTION
Starting from ruby 2.2 you can use the colon as pair separator even for quoted or dynamic symbol keys.  It is pretty cool when it comes to specifying HTML attributes.