### PR TITLE
ruby: iconv to encode snippet

### DIFF
--- a/lib/ruby/iconv_to_encode.rb
+++ b/lib/ruby/iconv_to_encode.rb
@@ -1,0 +1,41 @@
+Synvert::Rewriter.new 'ruby', 'iconv_to_encode' do
+  description <<-EOF
+It convert Iconv#iconv to String#encode
+
+    Iconv.new('cp1252', 'utf-8').iconv(string)
+    =>
+    string.force_encoding('utf-8').encode('cp1252')
+  EOF
+
+  within_files '**/*.rb' do
+    #Iconv.new('cp1252', 'utf-8').iconv(string)
+    #=>
+    #string.force_encoding('cp1252').encode('utf-8')
+    #
+    #require 'iconv'
+    #=>
+    #
+    with_node type: 'send', message: 'require', arguments:['iconv'] do
+      remove
+    end
+
+    with_node type: 'send', message: 'iconv', arguments: {size: 1} do
+      replace_with "{{arguments}}.{{receiver}}"
+    end
+    with_node type: 'send', receiver: 'Iconv', message: 'new', arguments: {size: 2} do
+      to_charset = node.arguments[0]
+      from_charset = node.arguments[1]
+      must_silently_ignore_bad_chars = from_charset.type == :str &&
+        from_charset.to_value.split("//").include?("IGNORE")
+      encode_options = ""
+      if(must_silently_ignore_bad_chars)
+        encode_options = ", invalid: :replace, undef: :replace"
+      end
+      cleaned_from_charset = from_charset.to_source.gsub(/\/{2}[^\/']+/,'')
+      cleaned_to_charset = to_charset.to_source.gsub(/\/{2}[^\/']+/,'')
+      replace_with(
+        "force_encoding(#{cleaned_from_charset}).encode(#{cleaned_to_charset}#{encode_options})"
+      )
+    end
+  end
+end

--- a/spec/ruby/iconv_to_encode_spec.rb
+++ b/spec/ruby/iconv_to_encode_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe 'Ruby Iconv#iconv to String#encode' do
+
+  before do
+    rewriter_path = File.join(File.dirname(__FILE__), '../../lib/ruby/iconv_to_encode.rb')
+    @rewriter = eval(File.read(rewriter_path))
+  end
+
+  describe 'with fakefs', fakefs: true do
+    describe 'basic case' do    
+      let(:test_content) {"
+        Iconv.new('Windows-1252','utf-8').iconv('some string')
+      "}
+      let(:test_rewritten_content) {"
+        'some string'.force_encoding('utf-8').encode('Windows-1252')
+      "}
+
+      it 'converts' do
+        File.write 'test.rb', test_content
+        @rewriter.process
+        expect(File.read 'test.rb').to eq test_rewritten_content
+      end
+    end
+    
+    describe 'with iconv ignored option' do
+      let(:test_content) {"
+        Iconv.new('Windows-1252//IGNORE','utf-8//IGNORE').iconv('some string')
+      "}
+      let(:test_rewritten_content) {"
+        'some string'.force_encoding('utf-8').encode('Windows-1252', invalid: :replace, undef: :replace)
+      "}
+
+      it 'converts' do
+        File.write 'test.rb', test_content
+        @rewriter.process
+        expect(File.read 'test.rb').to eq test_rewritten_content
+      end
+    end
+
+    describe 'case with encodings set in vars' do
+      let(:test_content) { "Iconv.new(to_charset, from_charset).iconv(line)" }
+      let(:test_rewritten_content) { "line.force_encoding(from_charset).encode(to_charset)" }
+
+      it 'converts' do
+        File.write 'test.rb', test_content
+        @rewriter.process
+        expect(File.read 'test.rb').to eq test_rewritten_content
+      end
+    end
+
+    describe 'remove iconv requires' do
+      let(:test_content) { "
+        require 'iconv'
+        require 'foo'
+      " }
+      let(:test_rewritten_content) { "
+        require 'foo'
+      " }
+
+      it 'converts' do
+        File.write 'test.rb', test_content
+        @rewriter.process 
+        expect(File.read 'test.rb').to eq test_rewritten_content
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Iconv is supported until ruby 1.9.x, then it converts Iconv to String#encode