### PR TITLE
Safe Navigator Argument Support

### DIFF
--- a/lib/ruby/new_safe_navigation_operator.rb
+++ b/lib/ruby/new_safe_navigation_operator.rb
@@ -2,10 +2,6 @@ Synvert::Rewriter.new 'ruby', 'new_safe_navigation_operator' do
   description <<-EOF
 Use ruby new safe navigation operator.
 
-    u && u.profile && u.profile.thumbnails && u.profiles.thumbnails.large
-    =>
-    u&.profile&.thumbnails&.large
-
     u.try!(:profile).try!(:thumbnails).try!(:large)
     =>
     u&.profile&.thumbnails&.large

--- a/lib/ruby/new_safe_navigation_operator.rb
+++ b/lib/ruby/new_safe_navigation_operator.rb
@@ -2,23 +2,28 @@ Synvert::Rewriter.new 'ruby', 'new_safe_navigation_operator' do
   description <<-EOF
 Use ruby new safe navigation operator.
 
-    u.try!(:profile).try!(:thumbnails).try!(:large)
+    u.try!(:profile).try(:thumbnails).try(:large, 100, format: 'jpg')
     =>
-    u&.profile&.thumbnails&.large
+    u&.profile&.thumbnails&.large(100, format: 'jpg')
   EOF
+
 
   # Gem::Version initialize will strip RUBY_VERSION directly in ruby 1.9,
   # which is solved from ruby 2.0.0, which calls dup internally.
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.3.0")
     within_files '**/*.rb' do
-      # u.try!(:profile).try!(:thumbnails).try!(:large)
-      # u.try(:profile).try(:thumbnails).try(:large)
+      # u.try!(:profile).try!(:thumbnails).try!(:large, 100, format: 'jpg')
+      # u.try(:profile).try(:thumbnails).try(:large, 100, format: 'jpg')
       # =>
-      # u&.profile&.thumbnails&.large
-      # u&.profile&.thumbnails&.large
+      # u.?profile.?thumbnails.?large(100, format: 'jpg')
+      # u.?profile.?thumbnails.?large(100, format: 'jpg')
       %w(try! try).each do |message|
         within_node type: 'send', message: message do
-          replace_with "{{receiver}}&.{{arguments.first.to_value}}"
+          if node.arguments.size == 1
+            replace_with "{{receiver}}&.{{arguments.first.to_value}}"
+          else
+            replace_with "{{receiver}}&.{{arguments.first.to_value}}({{arguments[1..-1]}})"
+          end
         end
       end
     end

--- a/lib/ruby/new_safe_navigation_operator.rb
+++ b/lib/ruby/new_safe_navigation_operator.rb
@@ -4,11 +4,11 @@ Use ruby new safe navigation operator.
 
     u && u.profile && u.profile.thumbnails && u.profiles.thumbnails.large
     =>
-    u.?profile.?thumbnails.?large
+    u&.profile&.thumbnails&.large
 
     u.try!(:profile).try!(:thumbnails).try!(:large)
     =>
-    u.?profile.?thumbnails.?large
+    u&.profile&.thumbnails&.large
   EOF
 
   # Gem::Version initialize will strip RUBY_VERSION directly in ruby 1.9,
@@ -18,8 +18,8 @@ Use ruby new safe navigation operator.
       # u.try!(:profile).try!(:thumbnails).try!(:large)
       # u.try(:profile).try(:thumbnails).try(:large)
       # =>
-      # u.?profile.?thumbnails.?large
-      # u.?profile.?thumbnails.?large
+      # u&.profile&.thumbnails&.large
+      # u&.profile&.thumbnails&.large
       %w(try! try).each do |message|
         within_node type: 'send', message: message do
           replace_with "{{receiver}}&.{{arguments.first.to_value}}"

--- a/spec/ruby/new_safe_navigation_operator_spec.rb
+++ b/spec/ruby/new_safe_navigation_operator_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe 'Ruby uses new safe navigation operator', skip: Gem::Version.new(
   describe 'with fakefs', fakefs: true do
     let(:test_content) {"
 u = User.find(id)
-u.try!(:profile).try!(:thumbnails).try!(:large)
-u.try!('profile').try!('thumbnails').try!('large')
-u.try(:profile).try(:thumbnails).try(:large)
-u.try('profile').try('thumbnails').try('large')
+u.try!(:profile).try!(:thumbnails).try!(:large, 100, format: 'jpg')
+u.try!('profile').try!('thumbnails').try!('large', 100, format: 'jpg')
+u.try(:profile).try(:thumbnails).try(:large, 100, format: 'jpg')
+u.try('profile').try('thumbnails').try('large', 100, format: 'jpg')
     "}
     let(:test_rewritten_content) {"
 u = User.find(id)
-u&.profile&.thumbnails&.large
-u&.profile&.thumbnails&.large
-u&.profile&.thumbnails&.large
-u&.profile&.thumbnails&.large
+u&.profile&.thumbnails&.large(100, format: 'jpg')
+u&.profile&.thumbnails&.large(100, format: 'jpg')
+u&.profile&.thumbnails&.large(100, format: 'jpg')
+u&.profile&.thumbnails&.large(100, format: 'jpg')
     "}
 
     it 'converts' do


### PR DESCRIPTION
This adds support for converting arguments with try and the safe navigation operator. Previously all arguments were being discarded.

Input
```ruby
a.try(:b, 1, 2)
```

Old Output
```ruby
a&.b
```

New Output
```ruby
a&.b(1, 2)
```
