### PR TITLE
gsub('_','ab') is not equivalent to tr('_','ab')

### DIFF
--- a/lib/ruby/gsub_to_tr.rb
+++ b/lib/ruby/gsub_to_tr.rb
@@ -12,7 +12,7 @@ It converts String#gsub to String#tr
     # =>
     # 'slug from title'.tr(' ', '_')
     with_node type: 'send', message: 'gsub', arguments: {size: 2, first: {type: 'str'}, last: {type: 'str'}} do
-      if node.arguments.first.to_value.length == 1
+      if node.arguments.first.to_value.length == 1 && node.arguments.last.to_value.length < 2
         replace_with "{{receiver}}.tr({{arguments}})"
       end
     end


### PR DESCRIPTION
when the second argument has 0 or 1 character, the result is correct, so allow those cases,
but disallow the transformation otherwise.