### PR TITLE
Nested conversion for update_4_2_to_5_0

### DIFF
--- a/lib/rails/upgrade_4_2_to_5_0.rb
+++ b/lib/rails/upgrade_4_2_to_5_0.rb
@@ -50,7 +50,7 @@ Synvert::Rewriter.new 'rails', 'upgrade_4_2_to_5_0' do
     end
   end
 
-  within_file 'app/controllers/*.rb' do
+  within_file 'app/controllers/**/*.rb' do
     # render nothing: true
     # =>
     # head :ok
@@ -85,7 +85,7 @@ Synvert::Rewriter.new 'rails', 'upgrade_4_2_to_5_0' do
   new_code << "end"
   add_file 'app/models/application_record.rb', new_code
 
-  within_files 'app/models/*.rb' do
+  within_files 'app/models/**/*.rb' do
     # after_commit :add_to_index_later, on: :create
     # after_commit :update_in_index_later, on: :update
     # after_commit :remove_from_index_later, on: :destroy
@@ -114,7 +114,7 @@ Synvert::Rewriter.new 'rails', 'upgrade_4_2_to_5_0' do
   new_code = "class ApplicationJob < ActiveJob::Base\n\nend"
   add_file 'app/jobs/application_job.rb', new_code
 
-  within_files 'app/jobs/*.rb' do
+  within_files 'app/jobs/**/*.rb' do
     # class PostJob < ActiveJob::Base
     # end
     # =>


### PR DESCRIPTION
Controllers, models, and jobs should be converted by recursing through directories.

The spec was updated to included a nested example for each of the above.

Also, `aggregate_failures` metadata was added to always check all expectations in the spec.