### PR TITLE
Flash types other than alert and notice need to be placed in flash hash

### DIFF
--- a/lib/rails/redirect_with_flash.rb
+++ b/lib/rails/redirect_with_flash.rb
@@ -31,10 +31,10 @@ Synvert::Rewriter.new 'rails', 'redirect_with_flash' do
       with_node type: 'send', receiver: nil, message: :redirect_to do
         if line.present? && node.line == line+1
           @actions << remover_action
-          if flash_type == ':error'
-            replace_with "{{message}} {{arguments}}, flash: {error: #{msg}}"
-          else
+          if [':notice', ':alert'].include?(flash_type)
             replace_with "{{message}} {{arguments}}, #{flash_type[1..-1]}: #{msg}"
+          else
+            replace_with "{{message}} {{arguments}}, flash: {#{flash_type[1..-1]}: #{msg}}"
           end
         end
       end

--- a/spec/rails/redirect_with_flash_spec.rb
+++ b/spec/rails/redirect_with_flash_spec.rb
@@ -58,15 +58,53 @@ class UnfixablePostsController < ApplicationController
   end
 end'}
 
+    let(:users_controller_content) {'
+class UsersController < ApplicationController
+  def activate
+    User.find(params[:id]).activate!
+    flash[:message] = "User activated!"
+    redirect_to root_path
+  end
+end'}
+
+    let(:users_controller_rewritten_content) {'
+class UsersController < ApplicationController
+  def activate
+    User.find(params[:id]).activate!
+    redirect_to root_path, flash: {message: "User activated!"}
+  end
+end'}
+
+    let(:admins_controller_content) {'
+class AdminsController < ApplicationController
+  def list
+    Admin.find(params[:id]).list!
+    flash[:alert] = "Admin listed!"
+    redirect_to root_path
+  end
+end'}
+
+    let(:admins_controller_rewritten_content) {'
+class AdminsController < ApplicationController
+  def list
+    Admin.find(params[:id]).list!
+    redirect_to root_path, alert: "Admin listed!"
+  end
+end'}
+
     it 'process' do
       FileUtils.mkdir_p 'app/controllers'
       File.write 'app/controllers/posts_controller.rb', posts_controller_content
       File.write 'app/controllers/comments_controller.rb', comments_controller_content
       File.write 'app/controllers/unfixable_posts_controller.rb', unfixable_posts_controller_content
+      File.write 'app/controllers/users_controller.rb', users_controller_content
+      File.write 'app/controllers/admins_controller.rb', admins_controller_content
       @rewriter.process
       expect(File.read('app/controllers/posts_controller.rb')).to eq posts_controller_rewritten_content
       expect(File.read('app/controllers/comments_controller.rb')).to eq comments_controller_rewritten_content
       expect(File.read('app/controllers/unfixable_posts_controller.rb')).to eq unfixable_posts_controller_content
+      expect(File.read('app/controllers/users_controller.rb')).to eq users_controller_rewritten_content
+      expect(File.read('app/controllers/admins_controller.rb')).to eq admins_controller_rewritten_content
     end
   end
 end


### PR DESCRIPTION
Adding :alert to the types which can be placed in a bare Hash; all
others will be passed in a Hash nested inside a top-level flash Hash.