### PR TITLE
Minor spec utility helper

### DIFF
--- a/spec/rails/redirect_with_flash_spec.rb
+++ b/spec/rails/redirect_with_flash_spec.rb
@@ -91,19 +91,34 @@ class AdminsController < ApplicationController
   end
 end'}
 
-    it 'process' do
-      FileUtils.mkdir_p 'app/controllers'
-      File.write 'app/controllers/posts_controller.rb', posts_controller_content
-      File.write 'app/controllers/comments_controller.rb', comments_controller_content
-      File.write 'app/controllers/unfixable_posts_controller.rb', unfixable_posts_controller_content
-      File.write 'app/controllers/users_controller.rb', users_controller_content
-      File.write 'app/controllers/admins_controller.rb', admins_controller_content
-      @rewriter.process
-      expect(File.read('app/controllers/posts_controller.rb')).to eq posts_controller_rewritten_content
-      expect(File.read('app/controllers/comments_controller.rb')).to eq comments_controller_rewritten_content
-      expect(File.read('app/controllers/unfixable_posts_controller.rb')).to eq unfixable_posts_controller_content
-      expect(File.read('app/controllers/users_controller.rb')).to eq users_controller_rewritten_content
-      expect(File.read('app/controllers/admins_controller.rb')).to eq admins_controller_rewritten_content
+    it 'uses shorter syntax for :notice' do
+      verifying_content_change('app/controllers/posts_controller.rb', posts_controller_content, posts_controller_rewritten_content) do
+        @rewriter.process
+      end
+    end
+
+    it 'uses shorter syntax for :alert' do
+      verifying_content_change('app/controllers/admins_controller.rb', admins_controller_content, admins_controller_rewritten_content) do
+        @rewriter.process
+      end
+    end
+
+    it 'uses longer syntax for :error' do
+      verifying_content_change('app/controllers/comments_controller.rb', comments_controller_content, comments_controller_rewritten_content) do
+        @rewriter.process
+      end
+    end
+
+    it 'does not rewrite if flash and redirect are not adjacent' do
+      verifying_content_change('app/controllers/unfixable_posts_controller.rb', unfixable_posts_controller_content, unfixable_posts_controller_content) do
+        @rewriter.process
+      end
+    end
+
+    it 'uses longer syntax for :message' do
+      verifying_content_change('app/controllers/users_controller.rb', users_controller_content, users_controller_rewritten_content) do
+        @rewriter.process
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,11 @@ RSpec.configure do |config|
     allow_any_instance_of(Synvert::Core::Rewriter::GemSpec).to receive(:match?).and_return(true)
   end
   config.expose_dsl_globally = false
+
+  def verifying_content_change(filename, before_content, after_content)
+    FileUtils.mkdir_p(File.dirname(filename))
+    File.write filename, before_content
+    yield
+    expect(File.read(filename)).to eq after_content
+  end
 end


### PR DESCRIPTION
Think this change is worth making?  I think it's helpful because each test case shows up as a different case:

```text
rails redirect with flash snippet
  with fakefs
    uses shorter syntax for :notice
    does not rewrite if flash and redirect are not adjacent
    uses longer syntax for :error
    uses shorter syntax for :alert
    uses longer syntax for :message
```

and the helper can handle the `mkdir_p` call.   No worries if you think it's not a change worth making though.