### PR TITLE
Auto corrected by following Lint Ruby Performance/StringReplacement

### DIFF
--- a/lib/rspec/one_liner_expectation.rb
+++ b/lib/rspec/one_liner_expectation.rb
@@ -61,7 +61,7 @@ Synvert::Rewriter.new 'rspec', 'one_liner_expectation' do
               EOS
             else
               replace_with <<~EOS
-                it '#{old_matcher.to_s.sub('have', 'has').gsub('_', ' ')} #{times} #{items_name}' do
+                it '#{old_matcher.to_s.sub('have', 'has').tr('_', ' ')} #{times} #{items_name}' do
                   expect(subject.#{items_name}.size).#{new_message} #{new_matcher} #{times}
                 end
               EOS


### PR DESCRIPTION
Auto corrected by following Lint Ruby Performance/StringReplacement

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-snippets/lint_configs/ruby/105495) to configure it on awesomecode.io