### PR TITLE
Auto corrected by following Lint Ruby Layout/ClosingHeredocIndentation

### DIFF
--- a/spec/rails/add_application_job_spec.rb
+++ b/spec/rails/add_application_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Add ApplicationJob' do
     let(:test_rewritten_content) { <<~EOS }
         class ApplicationJob < ActiveJob::Base
         end
-      EOS
+    EOS
 
     include_examples 'convertable'
   end
@@ -21,11 +21,11 @@ RSpec.describe 'Add ApplicationJob' do
     let(:test_content) { <<~EOS }
         class PostJob < ActiveJob::Base
         end
-      EOS
+    EOS
     let(:test_rewritten_content) { <<~EOS }
         class PostJob < ApplicationJob
         end
-      EOS
+    EOS
 
     include_examples 'convertable'
   end

--- a/spec/rails/add_application_record_spec.rb
+++ b/spec/rails/add_application_record_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Add ApplicationRecord' do
         class ApplicationRecord < ActiveRecord::Base
           self.abstract_class = true
         end
-      EOS
+    EOS
 
     include_examples 'convertable'
   end
@@ -22,11 +22,11 @@ RSpec.describe 'Add ApplicationRecord' do
     let(:test_content) { <<~EOS }
         class Post < ActiveRecord::Base
         end
-      EOS
+    EOS
     let(:test_rewritten_content) { <<~EOS }
         class Post < ApplicationRecord
         end
-      EOS
+    EOS
 
     include_examples 'convertable'
   end

--- a/spec/rails/upgrade_3_0_to_3_1_spec.rb
+++ b/spec/rails/upgrade_3_0_to_3_1_spec.rb
@@ -72,7 +72,7 @@ end
       ActiveSupport.on_load(:active_record) do
         self.include_root_in_json = false
       end
-    EOS
+  EOS
   let(:session_store_content) {
     "
 Synvert::Application.config.session_store :cookie_store, key: 'somethingold'

--- a/spec/ruby/new_2_2_hash_syntax_spec.rb
+++ b/spec/ruby/new_2_2_hash_syntax_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe 'Uses ruby 2.2 new hash synax' do
       { foo_key: 'foo_value', bar_key: 42, "baz-key" => true }
       { :"foo-#{key}" => 'foo_value', :"bar-key" => 42, :"a\tb" => false, :"c'd" => nil }
       { "foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil }
-    EOS
+  EOS
   let(:test_rewritten_content) { <<~'EOS' }
       { foo: 'bar', 'foo' => 'bar' }
       { key1: 'value1', key2: 'value2' }
       { foo_key: 'foo_value', bar_key: 42, "baz-key" => true }
       { "foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil }
       { "foo-#{key}": 'foo_value', 'bar-key': 42, "a\tb": false, "c'd": nil }
-    EOS
+  EOS
 
   before do
     load_sub_snippets(%w[ruby/new_1_9_hash_syntax])


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/ClosingHeredocIndentation

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-snippets/lint_configs/ruby/105576) to configure it on awesomecode.io