### PR TITLE
Auto corrected by following Lint Ruby Style/RegexpLiteral

### DIFF
--- a/lib/ruby/iconv_to_encode.rb
+++ b/lib/ruby/iconv_to_encode.rb
@@ -39,8 +39,8 @@ Synvert::Rewriter.new 'ruby', 'iconv_to_encode' do
       if must_silently_ignore_bad_chars
         encode_options = ', invalid: :replace, undef: :replace'
       end
-      cleaned_from_charset = from_charset.to_source.gsub(/\/{2}[^\/']+/, '')
-      cleaned_to_charset = to_charset.to_source.gsub(/\/{2}[^\/']+/, '')
+      cleaned_from_charset = from_charset.to_source.gsub(%r{/{2}[^/']+}, '')
+      cleaned_to_charset = to_charset.to_source.gsub(%r{/{2}[^/']+}, '')
       replace_with("force_encoding(#{cleaned_from_charset}).encode(#{cleaned_to_charset}#{encode_options})")
     end
   end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RegexpLiteral

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-snippets/lint_configs/ruby/105350) to configure it on awesomecode.io